### PR TITLE
Make binary more portable with #!/usr/bin/env php

### DIFF
--- a/bin/sculpt
+++ b/bin/sculpt
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 require dirname(__FILE__) . '/../vendor/autoload.php';
 


### PR DESCRIPTION
http://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html

It was making me crazy about changing my php.ini to increase memory_limit and it wasn't working. So I figured out it was trying to use an unused version of php.

```
$ where php

/Users/rogerio/.phpenv/shims/php
/usr/local/bin/php
/usr/local/bin/php
/usr/bin/php
```
